### PR TITLE
Fixed big lag spike with the chargejump

### DIFF
--- a/scripts/hooks/Player.lua
+++ b/scripts/hooks/Player.lua
@@ -51,6 +51,8 @@ function Player:init(chara, x, y)
 	self.climb_inv_timer = 0
 	self.falseloop = false
 	self.falseloopx = {}
+
+    self.climbareas = {}
 end
 
 function Player:beginClimb(last_state)
@@ -640,7 +642,7 @@ function Player:canClimb(dx, dy)
     Object.startCache()
     local climbarea
     local trigger
-    for _, event in ipairs(self.world.stage:getObjects(Event)) do
+    for _, event in ipairs(self.climbareas) do
         ---@cast event Event.climbarea|Event.climbentry
         -- TODO: Find out where these numbers come from, because it sure isn't the actor
         local x,y = -17, -37
@@ -1049,6 +1051,9 @@ function Player:drawClimbReticle()
 end
 
 function Player:updateClimb()
+    self.climbareas = TableUtils.filter(self.world.stage:getObjects(Event), function (v)
+        return (v.preClimbEnter or v.climbable) and MathUtils.dist(self.x, self.y, v.x, v.y) <= (#self.charge_times+1)*(math.sqrt((v.width^2)+(v.height^2))/40)*40+40
+    end)
     if self:isMovementEnabled() and not self.physics.move_target then
         self:processClimbInputs()
         if self.jumpchargecon > 0 then


### PR DESCRIPTION
See I was making a really big room with like 100 climbareas and the climbing chargejump started lagging a lot.

I look into it and turns out the chargejump calls canClimb for every segment for every frame while you're charging it.
Since canClimb loops through every event (a hundred in my case) on the map to check if you can climb it, this causes a lot of lag.

So now this changes the Player hook to store a table of all of the climbareas in a certain range of the player, this reduces it from amount of segments loops to 1 loop(with one smaller one that goes through the closeby climbareas)

This seems to have reduced the amount of lag by a noticeable amount, to the point you almost cannot feel it at all.

Take this as your funnyfeline teaser of the month.